### PR TITLE
fix repeat message

### DIFF
--- a/background.js
+++ b/background.js
@@ -162,7 +162,6 @@ async function handleAnswerGeneration(port, tabId, pageContent, question) {
 
         // 只有当最后一条不是相同的用户消息时才添加
         if (!lastMessage || !lastMessage.isUser || lastMessage.content !== question) {
-            chatHistory.push({ content: question, isUser: true });
             sessionHistories[tabId] = chatHistory;
         }
 


### PR DESCRIPTION
删除了一条语句，不然会产生重复的消息历史，因为在background.js:380已经更新过了，deepseek r1因为这个报错
![image](https://github.com/user-attachments/assets/915846d7-b9d2-4992-809b-4555354745b1)
